### PR TITLE
Only set authorization settings when a username or password are supplied...

### DIFF
--- a/lib/puppet/provider/httpfile/ruby_net_http.rb
+++ b/lib/puppet/provider/httpfile/ruby_net_http.rb
@@ -119,7 +119,9 @@ Puppet::Type.type(:httpfile).provide(:ruby_net_http) do
     end
     req.body = opts[:body]
     req.content_type = opts[:content_type] || ''
-    req.basic_auth opts[:http_user], opts[:http_pass]
+    if not opts[:http_user].nil? or not opts[:http_pass].nil?
+      req.basic_auth opts[:http_user], opts[:http_pass]
+    end
     req.set_form_data(opts[:form_data] || {}) if verb.to_sym == :post
     req
   end


### PR DESCRIPTION
Changed the request code to only set HTTP Basic Auth options when a username or a password are actually specified.

I had some trouble downloading a file from some Google server (http://commondatastorage.googleapis.com/git-repo-downloads/repo in particular) because the server would react to the (invalid?) authorization header with 403 responses. This change only adds an authorization header if username or password are specified, solving that problem for me.
