### PR TITLE
Implement support for client certificates and change the verify_peer default

### DIFF
--- a/lib/puppet/provider/httpfile/ruby_net_http.rb
+++ b/lib/puppet/provider/httpfile/ruby_net_http.rb
@@ -77,6 +77,8 @@ Puppet::Type.type(:httpfile).provide(:ruby_net_http) do
       @conn.use_ssl = true
       @conn.ca_path = resource[:http_ssl_ca_path] if resource[:http_ssl_ca_path]
       @conn.ca_file = resource[:http_ssl_ca_file] if resource[:http_ssl_ca_file]
+      @conn.cert = OpenSSL::X509::Certificate.new(File.read(resource[:http_ssl_cert])) if resource[:http_ssl_cert]
+      @conn.key = OpenSSL::PKey::RSA.new(File.read(resource[:http_ssl_key])) if resource[:http_ssl_key]
       @conn.verify_mode = if resource[:http_ssl_verify]
         OpenSSL::SSL::VERIFY_PEER
       else

--- a/lib/puppet/type/httpfile.rb
+++ b/lib/puppet/type/httpfile.rb
@@ -144,6 +144,14 @@ Puppet::Type.newtype(:httpfile) do
          'certifications in PEM format'
   end
 
+  newparam(:http_ssl_cert) do
+    desc 'Sets path of a client certificate file in PEM format.'
+  end
+
+  newparam(:http_ssl_key) do
+    desc 'Sets path of a client key file in PEM format.'
+  end
+
   newparam(:http_request_content_type) do
     desc 'HTTP Request Content Type.'
   end


### PR DESCRIPTION
I've implemented support for client certificates. This allows httpfile to be used in a completely private and secure fashion like how puppet's puppet master and agents work.

Also puppet software should not be setting verify_peer = false by default.
