### PR TITLE
Added checksum check post download [issue 4]

### DIFF
--- a/lib/puppet/type/httpfile.rb
+++ b/lib/puppet/type/httpfile.rb
@@ -114,8 +114,15 @@ Puppet::Type.newtype(:httpfile) do
      newparam(parm)
   end
 
+  newparam(:quick_check, :boolean => true) do
+    desc 'Skips checksum comparison and relies solely on rsync style "quick ' +
+         'checks" where we only compare the timestamp and size. Default: false.'
+    newvalues :true, :false
+    defaultto false
+  end
+
   newparam(:expected_checksum) do
-    desc 'The exptected checksum of the file.'
+    desc 'The exptected checksum of the file. This option is mutually exclusive with quick_check.'
   end
 
   newparam(:sidecar_http_verb) do
@@ -218,6 +225,8 @@ Puppet::Type.newtype(:httpfile) do
     raise ArgumentError, 'httpfile: path is required' unless self[:path]
 
     if self[:expected_checksum]
+      fail "expected_checksum and quick_check are mutually exclusive" if self[:quick_check]
+
       case self[:checksum_type]
       when :content_md5, :sidecar_md5
         unless self[:expected_checksum].match(/^[0-9a-f]{32}$/)


### PR DESCRIPTION
This makes it so we do a final checksum validation of the file we download during create(). The file will be left on the machine even in failure but this should be fine as resources which depend on this httpfile resource will not run as they will have failed dependencies and on the next run, the file will be re-downloaded as the checksums won't match (unless upstream fixes their md5sum in which case we won't need to download the file again). It would probably be safer if we downloaded files to a temp file and moved it into place on verification but that complicates the local_checksum() method.
